### PR TITLE
Add Google Colab Support with Streamlit Web Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Or use the UI (recommended for exploration)
    # If the browser doesn't open automatically, go to:
    # http://localhost:8501
 
+Run on Google Colab (web UI, keeps Tk UI for desktop)
+- This project includes a Colab-friendly launcher that exposes the existing Streamlit UI via an ngrok public URL. The Tkinter desktop app is preserved for local use; nothing was removed.
+- Steps in a Colab cell:
+   !git clone YOUR_REPO_URL
+   %cd YOUR_REPO_FOLDER
+   !python -m pip install -r requirements.txt
+   # Optional: set your ngrok token for a stable public URL
+   import os
+   os.environ["NGROK_AUTH_TOKEN"] = "YOUR_TOKEN"  # or NGROK_TOKEN
+   # Launch the web UI and get a public URL
+   !python run.py --colab
+- The notebook output will print a line like:
+   ================= PUBLIC URL =================
+   https://xxxxxxxx.ngrok.io
+   ==============================================
+  Click that URL to access the UI from your browser while the Colab runtime is running.
+- You can change the port by setting UI_PORT, e.g.:
+   os.environ["UI_PORT"] = "8502"
+
 UI tabs
 - Backtest: run cost-aware walk-forward with progress and charts.
 - Realtime (rich): train a rich-feature LightGBM model and preview minute-by-minute predictions with online correctness and confidence.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ yfinance>=0.2.40
 google-generativeai>=0.7.2
 requests>=2.32.3
 optuna>=3.6.0
+pyngrok>=7.1.6

--- a/run.py
+++ b/run.py
@@ -40,8 +40,17 @@ def main():
         run(f'"{sys.executable}" -m streamlit run "{ui_script}" --server.port {port}')
         return
 
+    # Colab-friendly web launcher (Streamlit + ngrok)
+    if "--colab" in args or "colab" in args:
+        colab_script = os.path.join("src", "colab_web.py")
+        if not os.path.exists(colab_script):
+            print(f"{colab_script} not found.")
+            raise SystemExit(1)
+        run(f'"{sys.executable}" "{colab_script}"')
+        return
+
     # Otherwise forward all args to the pipeline
-    extra_args = [a for a in sys.argv[1:] if a not in {"--ui", "ui", "--streamlit", "--tk", "tk"}]
+    extra_args = [a for a in sys.argv[1:] if a not in {"--ui", "ui", "--streamlit", "--tk", "tk", "--colab", "colab"}]
     extra = " ".join([f'"{a}"' if " " in a else a for a in extra_args])
     script = os.path.join("src", "run_pipeline.py")
     if not os.path.exists(script):

--- a/src/colab_web.py
+++ b/src/colab_web.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import time
+import subprocess
+from typing import Optional
+
+# This helper launches the existing Streamlit UI and exposes it publicly in Google Colab
+# using an ngrok tunnel. The Tkinter app remains available via `python run.py --tk` locally.
+
+def _install_if_missing(pkg: str):
+    try:
+        __import__(pkg)
+    except Exception:
+        print(f"+ Installing missing dependency: {pkg}")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+def main():
+    # Ensure pyngrok is available
+    _install_if_missing("pyngrok")
+
+    from pyngrok import ngrok  # type: ignore
+
+    # Configure auth token if provided
+    token = os.environ.get("NGROK_AUTH_TOKEN") or os.environ.get("NGROK_TOKEN")
+    if token:
+        try:
+            ngrok.set_auth_token(token)
+            print("+ ngrok auth token configured")
+        except Exception as e:
+            print(f"! Failed to set ngrok token: {e}")
+
+    # Determine port and UI script
+    port = int(os.environ.get("UI_PORT", "8501"))
+    ui_script = os.path.join("src", "ui_app.py")
+    if not os.path.exists(ui_script):
+        print(f"{ui_script} not found.")
+        raise SystemExit(1)
+
+    # Launch Streamlit
+    streamlit_cmd = [
+        sys.executable, "-m", "streamlit", "run", ui_script,
+        "--server.port", str(port),
+        "--server.headless", "true",
+        "--browser.gatherUsageStats", "false",
+    ]
+    print("+ Starting Streamlit UI...")
+    print("+ Command:", " ".join(streamlit_cmd))
+    st_proc = subprocess.Popen(streamlit_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    # Open public tunnel
+    print(f"+ Opening ngrok tunnel on port {port} ...")
+    public_url = None
+    try:
+        http_tunnel = ngrok.connect(port, "http")
+        public_url = http_tunnel.public_url
+        print("\n================= PUBLIC URL =================")
+        print(public_url)
+        print("==============================================\n")
+        print("Tip: In Google Colab, click the URL above to open the web UI.\n")
+    except Exception as e:
+        print(f"! Failed to open ngrok tunnel: {e}")
+        print("You can still access via the notebook proxy or local port forwarding if available.")
+
+    # Stream logs to console for visibility in Colab
+    try:
+        assert st_proc.stdout is not None
+        for line in st_proc.stdout:
+            print(line, end="")
+            # Print the public URL periodically to keep it visible
+            if public_url and ("Network URL" in line or "Local URL" in line):
+                print(f"\n[Public URL] {public_url}\n")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            st_proc.terminate()
+        except Exception:
+            pass
+        try:
+            ngrok.kill()
+        except Exception:
+            pass
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces the ability to run the project on Google Colab while preserving the existing Tkinter interface for local use. 

### Changes Made:
- Updated `README.md` to include instructions for launching the web UI in Colab, which utilizes an ngrok public URL for access.
- Added `pyngrok` package to `requirements.txt` to facilitate the public url connection.
- Modified `run.py` to include a new argument for launching the Colab web interface, delegating to a new script `colab_web.py`.
- Created `src/colab_web.py`, which manages the ngrok connection and launches the existing Streamlit application. 

### How to Run:
To launch the application in Colab, follow the provided instructions in the README. This enhancement allows for a seamless transition between local and Colab environments without losing access to the Tkinter desktop application.

---

> This pull request was co-created with Cosine Genie

Original Task: [Binomo-Bot/igzvgwsj1eve](https://cosine.sh/p0drixu2k2bx/Binomo-Bot/task/igzvgwsj1eve)
Author: Janith Manodaya
